### PR TITLE
Update command line arguments when running the examples locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dist-min": "webpack --mode=production --config webpack.config.min.js",
     "dist-example": "webpack --mode=development --config webpack.config.example.js",
     "dist-example-min": "webpack --mode=production --config webpack.config.example.min.js",
-    "start": "webpack-dev-server --content-base examples/"
+    "start": "webpack-dev-server --static examples/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Dear maintainers, 

apparently, webpack > 5 replaced "content-base" with "static". Changing this line allows to run the examples successfully on more recent webpack versions.

All the best
