### PR TITLE
Update the A-Frame version used in the examples to latest release 1.4.2

### DIFF
--- a/examples/all_components_colors.html
+++ b/examples/all_components_colors.html
@@ -3,7 +3,7 @@
 <head>
   	<meta charset="utf-8">
   	<title>A-Frame GUI Colors</title>
-    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.2/dist/aframe-master.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.5.1/dat.gui.min.js" type="text/javascript"></script>
 
     <script src="js/aframe-gui.js"></script>

--- a/examples/all_components_mouse_quest.html
+++ b/examples/all_components_mouse_quest.html
@@ -3,7 +3,7 @@
 <head>
   	<meta charset="utf-8">
   	<title>A-Frame GUI All Components</title>
-    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.2/dist/aframe-master.min.js"></script>
  	<script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.5.1/dat.gui.min.js" type="text/javascript"></script>
 
     <script src="js/aframe-gui.js"></script>

--- a/examples/casestudy_amper.html
+++ b/examples/casestudy_amper.html
@@ -3,7 +3,7 @@
 <head>
   	<meta charset="utf-8">
   	<title>A-Frame GUI</title>
-    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.2/dist/aframe-master.min.js"></script>
 	<style type="text/css">
 		@font-face{
 			font-family:"Ionicons";

--- a/examples/casestudy_call.html
+++ b/examples/casestudy_call.html
@@ -3,7 +3,7 @@
 <head>
   	<meta charset="utf-8">
   	<title>A-Frame GUI Call</title>
-    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.2/dist/aframe-master.min.js"></script>
 
     <script src="js/aframe-gui.js"></script>
     <script src="js/gui-env.js"></script>

--- a/examples/casestudy_dropdown.html
+++ b/examples/casestudy_dropdown.html
@@ -3,7 +3,7 @@
 <head>
   	<meta charset="utf-8">
   	<title>A-Frame GUI Dropdown</title>
-    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.2/dist/aframe-master.min.js"></script>
 
     <script src="js/aframe-gui.js"></script>
     <script src="js/gui-env.js"></script>

--- a/examples/casestudy_eyetest.html
+++ b/examples/casestudy_eyetest.html
@@ -3,7 +3,7 @@
 <head>
   	<meta charset="utf-8">
   	<title>A-Frame GUI Eye Test</title>
-    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.2/dist/aframe-master.min.js"></script>
 	<style type="text/css">
 		@font-face{
 			font-family:"Ionicons";

--- a/examples/casestudy_keyboard.html
+++ b/examples/casestudy_keyboard.html
@@ -3,7 +3,7 @@
 <head>
   	<meta charset="utf-8">
   	<title>A-Frame GUI Keyboard</title>
-    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.2/dist/aframe-master.min.js"></script>
 
     <script src="js/aframe-gui.js"></script>
     <script src="js/gui-env.js"></script>

--- a/examples/casestudy_movies.html
+++ b/examples/casestudy_movies.html
@@ -3,7 +3,7 @@
 <head>
   	<meta charset="utf-8">
   	<title>A-Frame GUI Movie Player</title>
-    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.2/dist/aframe-master.min.js"></script>
 
     <script src="js/aframe-gui.js"></script>
     <script src="js/gui-env.js"></script>

--- a/examples/casestudy_vrremote.html
+++ b/examples/casestudy_vrremote.html
@@ -3,7 +3,7 @@
 <head>
   	<meta charset="utf-8">
   	<title>A-Frame GUI Dropdown</title>
-    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.2/dist/aframe-master.min.js"></script>
 	<style type="text/css">
 		@font-face{
 			font-family:"Ionicons";


### PR DESCRIPTION
A follow up of #3 

This makes the examples behave as expected, e.g. labels on the UI are rendered, no console errors and so on.

All the best